### PR TITLE
Fix README regarding GitLab token

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Check the status of your CI/CD environments or Notifications using your Stream Deck
 
-- [How it works?](#how-it-works)
+- [How does it work?](#how-does-it-work)
   - [Install this plugin](#install-this-plugin)
   - [Configuration options](#configuration-options)
   - [Compatible services](#compatible-services)
@@ -22,7 +22,7 @@
   - [Support the project](#support-the-project)
   - [Issues](#issues)
 
-# How it works?
+# How does it work?
 
 ## Install this plugin
 

--- a/README.md
+++ b/README.md
@@ -121,25 +121,25 @@ By default the actions uses the **travis-ci.org** api, if you want to use it wit
 
 1. Install all the dependencies
 
-```bash
+```shell
 yarn
 ```
 
 2. Build the project for the first time, the project uses [Parcel as bundler](https://parceljs.org/) to handle React and TypeScript
 
-```bash
+```shell
 yarn build
 ```
 
 3. Create a symlink form the folder you clone the repository
 
-```
+```shell
 ln -s devops-streamdeck/dist/dev.santiagomartin.devops.sdPlugin ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/dev.santiagomartin.devops.sdPlugin
 ```
 
 1. Run the proper dev command, since we are using Parcel to build the project we have a few dev commands to start Parcel in watch mode
 
-```
+```parcel
 // For Property Inspector
 yarn:dev:pi
 
@@ -152,6 +152,7 @@ yarn:dev:setup
 
 ### Project structure
 
+```text
     .
     ├── node_modules
     ├── dist
@@ -173,6 +174,7 @@ yarn:dev:setup
     ├── README.md
     ├── tsconfig.json
     └── yarn.lock
+```
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@
     - [Netlify](#netlify)
     - [Vercel](#vercel)
     - [Travis-CI.com / Travis-CI.org](#travis-cicom--travis-ciorg)
-- [How to setup the dev environment](#how-to-setup-the-dev-environment)
-  - [Project structure](#project-structure)
-- [References](#references)
-- [Contributing](#contributing)
-- [Support the project](#support-the-project)
-- [Issues](#issues)
+  - [How to setup the dev environment](#how-to-setup-the-dev-environment)
+    - [Project structure](#project-structure)
+  - [References](#references)
+  - [Contributing](#contributing)
+  - [Support the project](#support-the-project)
+  - [Issues](#issues)
 
 # How it works?
 
@@ -45,7 +45,7 @@ You can find it at the Stream Deck Store. 🚀
 <details>
  <summary>Show information</summary>
 
- #### For public repositories
+#### For public repositories
 
 You have to create a new [Personal Token](https://github.com/settings/tokens) with the following scopes: **repo:status**, **repo_deployment** and **public_repo**.
 
@@ -117,7 +117,7 @@ By default the actions uses the **travis-ci.org** api, if you want to use it wit
 
 </details>
 
-# How to setup the dev environment
+## How to setup the dev environment
 
 1. Install all the dependencies
 
@@ -150,7 +150,7 @@ yarn:dev:plugin
 yarn:dev:setup
 ```
 
-## Project structure
+### Project structure
 
     .
     ├── node_modules
@@ -174,18 +174,18 @@ yarn:dev:setup
     ├── tsconfig.json
     └── yarn.lock
 
-# References
+## References
 
 - [Steam Deck SDK docs](https://developer.elgato.com/documentation/)
 
-# Contributing
+## Contributing
 
 Thank you for considering contributing to the **DevOps for Stream Deck**. Feel free to send in any pull requests.
 
-# Support the project
+## Support the project
 
 If you like the project, you can subscribe to my [Twitch channel](https://twitch.tv/santima10), where I do live coding of this and other projects.
 
-# Issues
+## Issues
 
 Please report any [issues](https://github.com/SantiMA10/devops-streamdeck/issues). Ideas for new excuse features are also welcomed.


### PR DESCRIPTION
The `api`scope is a little broad, as it allows read / write to all API endpoints, see [Personal Access Token scopes](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#personal-access-token-scopes) for reference.

Also includes a bunch of minor formatting / spelling fixes.